### PR TITLE
Temporarily disable the Similarweb test for additional domains

### DIFF
--- a/src/twofactorauth.js
+++ b/src/twofactorauth.js
@@ -19,7 +19,7 @@ export default async function(req, env) {
 
 			// Validate any additional domains
 			for (const domain of entry['additional-domains'] || []) {
-				await SimilarWeb(domain, env);
+				//await SimilarWeb(domain, env);
 				await Blocklist(entry.domain);
 			}
 


### PR DESCRIPTION
This PR temporarily disables the Similarweb test for additional domains until a better solution can be found. My opinion is that additional domains that fail the test should be treated as warnings rather than errors. In any case, this is a stopgap measure.

This should resolve the issues in 2factorauth/twofactorauth#8112, 2factorauth/twofactorauth#8106, and 2factorauth/twofactorauth#8109.