### PR TITLE
Use the base domain for Similarweb

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -24,8 +24,8 @@ class Logger {
 		return this.messages;
 	}
 
-	clearMessages(){
-		this.messages = []
+	clearMessages() {
+		this.messages = [];
 	}
 }
 

--- a/src/passkeys.js
+++ b/src/passkeys.js
@@ -3,7 +3,7 @@ import Facebook from './tests/Facebook.js';
 import Blocklist from './tests/Blocklist.js';
 import logger from './logger';
 
-export default async function(req, env) {
+export default async function (req, env) {
 	const { pr, repo } = req.params;
 	const repository = `${env.OWNER}/${repo}`;
 
@@ -18,17 +18,15 @@ export default async function(req, env) {
 
 			// Validate any additional domains
 			for (const domain of entry['additional-domains'] || []) {
-				await SimilarWeb(domain, env, entry.file)
+				await SimilarWeb(domain, env, entry.file);
 				await Blocklist(domain);
 			}
 
 			// Validate Facebook contact if present
 			if (entry.contact?.facebook) await Facebook(entry.contact.facebook);
-
 		} catch (e) {
 			// Return an error response if validation fails
-			return new Response(`::error file=${entry.file}:: ${e.message}`,
-				{ status: 400 });
+			return new Response(`::error file=${entry.file}:: ${e.message}`, { status: 400 });
 		}
 	}
 
@@ -47,13 +45,12 @@ export default async function(req, env) {
  * @returns {Promise<*[]>} Returns all modified entry files as an array.
  */
 async function fetchEntries(repo, pr) {
-	const data = await fetch(
-		`https://api.github.com/repos/${repo}/pulls/${pr}/files`, {
-			headers: {
-				'Accept': 'application/vnd.github.v3+json',
-				'User-Agent': '2factorauth/twofactorauth (+https://2fa.directory/bots)'
-			}
-		});
+	const data = await fetch(`https://api.github.com/repos/${repo}/pulls/${pr}/files`, {
+		headers: {
+			Accept: 'application/vnd.github.v3+json',
+			'User-Agent': '2factorauth/twofactorauth (+https://2fa.directory/bots)',
+		},
+	});
 
 	if (!data.ok) throw new Error(await data.text());
 

--- a/src/tests/SimilarWeb.js
+++ b/src/tests/SimilarWeb.js
@@ -4,7 +4,7 @@ const test = 'SimilarWeb';
 
 /**
  * Retrieve the Similarweb rank for a given domain
- * @param {string} domain The domain to check
+ * @param {string} entryDomain The domain to check
  * @param {*} env The environment
  * @param {string} [file] The filename of the entry, should only be set for non-primary domains
  * @returns {Promise<number>} Returns `0` if it's a success, `1` otherwise

--- a/src/tests/SimilarWeb.js
+++ b/src/tests/SimilarWeb.js
@@ -9,7 +9,8 @@ const test = 'SimilarWeb';
  * @param {string} [file] The filename of the entry, should only be set for non-primary domains
  * @returns {Promise<number>} Returns `0` if it's a success, `1` otherwise
  */
-export default async function (domain, env, file) {
+export default async function (entryDomain, env, file) {
+	const domain = getBaseDomain(entryDomain);
 	const res = await fetch(`https://api.similarweb.com/v1/similar-rank/${domain}/rank?api_key=${env.SIMILARWEB_API_KEY}`, {
 		cf: {
 			cacheTtlByStatus: {
@@ -55,4 +56,19 @@ export default async function (domain, env, file) {
 	logger.addMessage(test, `${domain} ranked ${rank.toLocaleString()}`);
 
 	return 0;
+}
+
+/**
+ * Return the base domain of a domain with possible subdomains
+ * @param {string} domain The domain to parse
+ * @returns {string} The base domain
+ */
+function getBaseDomain(hostname) {
+	let parts = hostname.split('.');
+	if (parts.length <= 2) return hostname;
+
+	parts = parts.slice(-3);
+	if (['co', 'com'].includes(parts[1])) return parts.join('.');
+
+	return parts.slice(-2).join('.');
 }


### PR DESCRIPTION
The PR ensures that only the base domain (i.e. `google.com` as opposed to `photos.google.com`) is used for checking the rank on Similarweb. It should fix the issue in 2factorauth/twofactorauth#8118.