### PR TITLE
Fix Similarweb "body used" error

### DIFF
--- a/src/tests/SimilarWeb.js
+++ b/src/tests/SimilarWeb.js
@@ -29,6 +29,8 @@ export default async function (entryDomain, env, file) {
 		const errorDetails = `HTTP error ${res.status}\nError message: ${await res.text()}`;
 		if (!file) throw new Error(`Unable to fetch website rank — ${errorDetails}`);
 		else logger.addWarning(file, `Unable to fetch website rank for additional domain ${domain} — ${errorDetails}`);
+
+		return 1;
 	}
 
 	const json = await res.json();


### PR DESCRIPTION
If a Similarweb response is not [OK](https://developer.mozilla.org/en-US/docs/Web/API/Response/ok) (status code not in the range of 200-299), then the test would continue after writing throwing or adding a warning. This PR updates the `!res.ok` block to return `1`, which signifies an unsuccessful response.

The error being displayed was: `Body has already been used. It can only be used once. Use tee() first if you need to read it twice.`